### PR TITLE
Video games filtered with respect to video duration.

### DIFF
--- a/src/main/app/src/constants/ActivitiesFilterBar.js
+++ b/src/main/app/src/constants/ActivitiesFilterBar.js
@@ -54,6 +54,9 @@ const VideosFilterBar = ({handleFilterChange, filterButtonClick, filterResetClic
             <option value="yoga">{"Yoga"}</option>
             <option value="workout">{"Workout"}</option>
             <option value="meditation">{"Meditation"}</option>
+            <option value="short">{"Videos less than 15 minutes"}</option>
+            <option value="medium">{"Videos greater than 15 minutes and less than 30 minutes"}</option>
+            <option value="large">{"Videos greater than 30 minutes"}</option>
           </select>
         </div></div>
         <FilterCommonSection filterButtonClick={filterButtonClick} filterResetClick={filterResetClick} />

--- a/src/main/app/src/hooks/browseActivitiesFilter.js
+++ b/src/main/app/src/hooks/browseActivitiesFilter.js
@@ -27,15 +27,15 @@ const filterActivities = (links, activityType, activityTypes, linkFilters, updat
 */
 const filterGames = (game, filters) => {
   var input = parseInt(filters.numOfPlayers,10);
-    var min = parseInt(game.minPlayer,10);
-    var max = parseInt(game.maxPlayer,10);
-    
-    return (min === 0 && max === 0) ||                 // If there are no restrictions on the number of players
-        (min === 0 && max >= input) ||              // If no restriciton on minPlayer, but there is a max limit satisfied
-        (max === 0 && min <= input) ||              // If no restriction on maxPLayer, but minimum limit is satisfied
-        (min <= input && max >= input);         // If both are non-zero, and the game players are within limit. 
-    
-    // Otherwise don't return. 
+  var min = parseInt(game.minPlayer,10);
+  var max = parseInt(game.maxPlayer,10);
+  
+  return (min === 0 && max === 0) ||                 // If there are no restrictions on the number of players
+      (min === 0 && max >= input) ||              // If no restriciton on minPlayer, but there is a max limit satisfied
+      (max === 0 && min <= input) ||              // If no restriction on maxPLayer, but minimum limit is satisfied
+      (min <= input && max >= input);         // If both are non-zero, and the game players are within limit. 
+  
+  // Otherwise don't return. 
 }
 
 /** Filter list of articles. */

--- a/src/main/app/src/hooks/browseActivitiesFilter.js
+++ b/src/main/app/src/hooks/browseActivitiesFilter.js
@@ -31,9 +31,9 @@ const filterGames = (game, filters) => {
   var max = parseInt(game.maxPlayer,10);
   
   return (min === 0 && max === 0) ||                 // If there are no restrictions on the number of players
-      (min === 0 && max >= input) ||              // If no restriciton on minPlayer, but there is a max limit satisfied
-      (max === 0 && min <= input) ||              // If no restriction on maxPLayer, but minimum limit is satisfied
-      (min <= input && max >= input);         // If both are non-zero, and the game players are within limit. 
+    (min === 0 && max >= input) ||              // If no restriciton on minPlayer, but there is a max limit satisfied
+    (max === 0 && min <= input) ||              // If no restriction on maxPLayer, but minimum limit is satisfied
+    (min <= input && max >= input);         // If both are non-zero, and the game players are within limit. 
   
   // Otherwise don't return. 
 }
@@ -43,9 +43,25 @@ const filterArticles = (article, filters) => {
   return filters.articleType === '*' || article.type === filters.articleType;
 }
 
-/** Filter list of videos. */
+/** 
+  Filter list of videos.
+  Short videos duration  -  [0,900]
+  Medium length videos - [901,1800]
+  Large length videos- (>=1801)
+*/
 const filterVideos = (video, filters) => {
-  return filters.videoType === '*' || video.type === filters.videoType;
+  var input = filters.videoLength; 
+  var duration = parseInt(video.duration);  
+  
+  if("short".localeCompare(input) === 0 ) {     
+    return (duration >= 0 && duration <= 900);
+  }
+  else if("medium".localeCompare(input) === 0 ) {
+    return (duration >= 901 && duration <= 1800);
+  }
+  else if("large".localeCompare(input) === 0) {
+    return (duration>=1801);     
+  }
 }
 
 export default filterActivities;

--- a/src/main/app/src/hooks/browseActivitiesFilter.js
+++ b/src/main/app/src/hooks/browseActivitiesFilter.js
@@ -30,10 +30,10 @@ const filterGames = (game, filters) => {
   var min = parseInt(game.minPlayer,10);
   var max = parseInt(game.maxPlayer,10);
   
-  return (min === 0 && max === 0) ||                 // If there are no restrictions on the number of players
-    (min === 0 && max >= input) ||              // If no restriciton on minPlayer, but there is a max limit satisfied
-    (max === 0 && min <= input) ||              // If no restriction on maxPLayer, but minimum limit is satisfied
-    (min <= input && max >= input);         // If both are non-zero, and the game players are within limit. 
+  return (min === 0 && max === 0) ||                  // If there are no restrictions on the number of players
+    (min === 0 && max >= input) ||                    // If no restriciton on minPlayer, but there is a max limit satisfied
+    (max === 0 && min <= input) ||                    // If no restriction on maxPLayer, but minimum limit is satisfied
+    (min <= input && max >= input);                   // If both are non-zero, and the game players are within limit. 
   
   // Otherwise don't return. 
 }

--- a/src/main/app/src/pages/BrowsePage.js
+++ b/src/main/app/src/pages/BrowsePage.js
@@ -7,6 +7,7 @@ import VideoCard from '../constants/VideoCard.js';
 import filterActivities from '../hooks/browseActivitiesFilter.js';
 import {GamesFilterBar, ArticlesFilterBar, VideosFilterBar} from '../constants/ActivitiesFilterBar';
 
+
 /* Component for browse page */
 const BrowsePage = ({ links, activityType, updateActivityType, updateActivity, updateServlet, 
   articleData, videoData, gameData, activityTypes }) => {
@@ -21,12 +22,14 @@ const BrowsePage = ({ links, activityType, updateActivityType, updateActivity, u
     This function calls the function that is declared in hooks folder to filter out games based on the entered value.
   */
   const filterButtonClick = evt => {
-   filterActivities(links, activityType, activityTypes, linkFilters, updateFilteredLinks);
+    filterActivities(links, activityType, activityTypes, linkFilters, updateFilteredLinks);
   }
 
   // When reset button is clicked, all the state go back to its default value (i.e, no filter) So, it displays all the links.
   const filterResetClick = evt => {
-    updateLinksFilters(Object.assign(linkFilters, delete linkFilters.numOfPlayers));     // numOfPLayers -1 if filter was reseted. In this case, filteredData will be links. 
+    // When the Reset button is clicked, delete all the filters such that linkFilters has no fields anymore, and filteredLinks points to links itself.
+    updateLinksFilters(Object.assign(linkFilters, delete linkFilters.numOfPlayers)); 
+    updateLinksFilters(Object.assign(linkFilters, delete linkFilters.videoLength));
     updateFilteredLinks(links);
     settextBoxValue("");
   }
@@ -44,7 +47,15 @@ const BrowsePage = ({ links, activityType, updateActivityType, updateActivity, u
           updateLinksFilters(Object.assign(linkFilters, {numOfPlayers: value}));
           break;
         case activityTypes.VIDEOS:
-          updateLinksFilters(Object.assign(linkFilters, {videoType: value}));
+          // If the activity length is the filter that needs to be taken care of. 
+          // These three drop down options come together as one in videoLength inside linkFilters. 
+          if(value==="short" || value === "medium" || value==="large") {
+            updateLinksFilters(Object.assign(linkFilters, {videoLength: value}));
+          }
+          else {
+            updateLinksFilters(Object.assign(linkFilters, delete linkFilters.videoLength));
+            // Code to handle other filters of activityType= Videos, in addition to deleting the length field from the filter.
+          }
           break;
         case activityTypes.ARTICLES:
           updateLinksFilters(Object.assign(linkFilters, {articleType: value}));
@@ -53,7 +64,7 @@ const BrowsePage = ({ links, activityType, updateActivityType, updateActivity, u
           console.log("Error: Invalid activity type selection.");
       }
     }
-    settextBoxValue(evt.target.value);
+    settextBoxValue(evt.target.value);    
   }
 
   // Update activty selection and web servlet state based on dropdown.

--- a/src/main/app/src/pages/BrowsePage.js
+++ b/src/main/app/src/pages/BrowsePage.js
@@ -7,7 +7,6 @@ import VideoCard from '../constants/VideoCard.js';
 import filterActivities from '../hooks/browseActivitiesFilter.js';
 import {GamesFilterBar, ArticlesFilterBar, VideosFilterBar} from '../constants/ActivitiesFilterBar';
 
-
 /* Component for browse page */
 const BrowsePage = ({ links, activityType, updateActivityType, updateActivity, updateServlet, 
   articleData, videoData, gameData, activityTypes }) => {
@@ -49,7 +48,7 @@ const BrowsePage = ({ links, activityType, updateActivityType, updateActivity, u
         case activityTypes.VIDEOS:
           // If the activity length is the filter that needs to be taken care of. 
           // These three drop down options come together as one in videoLength inside linkFilters. 
-          if(value==="short" || value === "medium" || value==="large") {
+          if (value === "short" || value === "medium" || value ==="large") {
             updateLinksFilters(Object.assign(linkFilters, {videoLength: value}));
           }
           else {

--- a/src/main/app/src/test.js
+++ b/src/main/app/src/test.js
@@ -8,13 +8,14 @@ const gameTempData = [
 ];
 
 const videoTempData = [
-  {"id": "5101015804149760", "creator": "Fit Tuber",	"publishedAt": "2020-03-20T13:30:06Z", "title":	"15 Min Daily Yoga Routine for Beginners (Follow Along)", "type": "yoga", "url":	"https://www.youtube.com/watch?v=s2NQhpFGIOg"},	
-  {"id": "5647930295844864", "creator": "645AR",	"publishedAt": "2020-04-03T04:00:16Z", "title":	"645AR - Meditation (Official Audio)", "type": "meditation", "url":	"https://www.youtube.com/watch?v=uvSuYh1esmg"},	
-  {"id": "5116357293113344", "creator": "Taarak Mehta Ka Ooltah Chashmah",	"publishedAt": "2020-08-13T15:45:00Z", "title":	"NEW! Ep 2970 - Babita Teaches Jethalal Yoga! | Taarak Mehta Ka Ooltah Chashmah Comedy | तारक मेहता", "type": "yoga", "url":	"https://www.youtube.com/watch?v=g7BCb8vLA6c"},
-  {"id": "5688142262697984", "creator":	"yoga flocke - body art", "publishedAt":	"2019-05-12T20:48:07Z", "title": 	"Ashtanga Workout - working the hip (leg behind the head)", "type": "workout", "url":	"https://www.youtube.com/watch?v=wAfPba4NtzE"},	
-  {"id": "5646113927331840", "creator":	"Xuan Lan Yoga", "publishedAt":	"2019-06-20T18:00:05Z", "title": 	"Tu Primera Clase de Meditation (Nivel principiante)", "type": "meditation", "url":	"https://www.youtube.com/watch?v=WamU36hXiNw"},	
-  {"id": "5928667746140160", "creator":	"Yoga With Adriene", "publishedAt":	"2018-09-16T08:00:03Z", "title": 	"Sunrise Yoga - 15 Min Morning Yoga Practice - Yoga With Adriene", "type": "yoga", "url":	"https://www.youtube.com/watch?v=r7xsYgTeM2Q"},	
-  {"id": "5083571056279552", "creator":	"Yoga with Kassandra", "publishedAt":	"2018-09-20T11:47:56Z", "title": 	"10 min Morning Workout Full Body Stretch", "type": "workout", "url":	"https://www.youtube.com/watch?v=4pKly2JojMw"}
+  {"id": "5101015804149760", "creator": "Fit Tuber","duration":"1199",	"publishedAt": "2020-03-20T13:30:06Z", "title":	"15 Min Daily Yoga Routine for Beginners (Follow Along)", "type": "yoga", "url":	"https://www.youtube.com/watch?v=s2NQhpFGIOg"},	
+  {"id": "5647930295844864", "creator": "645AR","duration":"1200","publishedAt": "2020-04-03T04:00:16Z", "title":	"645AR - Meditation (Official Audio)", "type": "meditation", "url":	"https://www.youtube.com/watch?v=uvSuYh1esmg"},	
+  {"id": "5116357293113344", "creator": "Taarak Mehta Ka Ooltah Chashmah","duration":"360",	"publishedAt": "2020-08-13T15:45:00Z", "title":	"NEW! Ep 2970 - Babita Teaches Jethalal Yoga! | Taarak Mehta Ka Ooltah Chashmah Comedy | तारक मेहता", "type": "yoga", "url":	"https://www.youtube.com/watch?v=g7BCb8vLA6c"},
+  {"id": "5688142262697984", "creator":	"yoga flocke - body art", "duration":"293", "publishedAt":	"2019-05-12T20:48:07Z", "title": 	"Ashtanga Workout - working the hip (leg behind the head)", "type": "workout", "url":	"https://www.youtube.com/watch?v=wAfPba4NtzE"},	
+  {"id": "5646113927331840", "creator":	"Xuan Lan Yoga","duration":"1462", "publishedAt":	"2019-06-20T18:00:05Z", "title": 	"Tu Primera Clase de Meditation (Nivel principiante)", "type": "meditation", "url":	"https://www.youtube.com/watch?v=WamU36hXiNw"},	
+  {"id": "5928667746140160", "creator":	"Yoga With Adriene","duration":"934", "publishedAt":	"2018-09-16T08:00:03Z", "title": 	"Sunrise Yoga - 15 Min Morning Yoga Practice - Yoga With Adriene", "type": "yoga", "url":	"https://www.youtube.com/watch?v=r7xsYgTeM2Q"},	
+  {"id": "5083571056279552", "creator":	"Yoga with Kassandra","duration":"656", "publishedAt":	"2018-09-20T11:47:56Z", "title": 	"10 min Morning Workout Full Body Stretch", "type": "workout", "url":	"https://www.youtube.com/watch?v=4pKly2JojMw"},
+  {"id": "4908504900960256", "creator":	"Yoga With Adriene","duration":"2326", "publishedAt":	"2013-01-23T16:01:07Z", "title": 	"Yoga For Weight Loss  |  Fat Burning Workout  |  Yoga With Adriene", "url":	"https://www.youtube.com/watch?v=Ci3na6ThUJc"}
 ];
 
 const articleTempData = [


### PR DESCRIPTION
Hi, 
This PR consists of filtering the Active videos wrt their duration. The filtering has been done in this way:
1. [Short video - less than 15 minutes](https://screenshot.googleplex.com/bd5d7cdb-da2b-4f02-b0ad-1ccb05860dbc.png)
2. [Medium video - less than 30 minutes and greater than 15 minutes.](https://screenshot.googleplex.com/6dacaad4-6759-44cf-adb3-fb529b88a6f9.png)
3. [Large videos - more than 30 minutes. ](https://screenshot.googleplex.com/ee04c64d-202d-46f2-ae6b-9909712a7990.png)
I have deployed the recent changes, so the deployed version should contain these filter changes. 
This is how the [drop down now looks](https://screenshot.googleplex.com/aa253ad9-d800-4a5e-9311-922aa732bac5.png)
These three options in the drop down menu are associated with the same field on linkFilters.videoLength, and these are edited when the length changes, and are deleted when the user clicks any other dropdown menu that are not related to the length of the video. Please take a look at it!
